### PR TITLE
Fix data source client spring dependency

### DIFF
--- a/case-datasource-client/pom.xml
+++ b/case-datasource-client/pom.xml
@@ -22,7 +22,7 @@
         <!-- Compile dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-rest</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
             <version>${springboot.version}</version>
         </dependency>
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
spring-boot-starter-data-rest dependency create issue when data source client is used by another service and spring boot 2.2.x
[https://stackoverflow.com/questions/58431876/spring-boot-2-2-0-spring-hateoas-startup-issue](https://stackoverflow.com/questions/58431876/spring-boot-2-2-0-spring-hateoas-startup-issue
)

**What is the new behavior (if this is a feature change)?**
spring-boot-starter-data-rest has been replaced by spring-boot-starter-web which is enough for rest template


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
