### PR TITLE
Fix bug when tso code not found

### DIFF
--- a/case-server/src/main/java/com/powsybl/caseserver/parsers/cgmes/SourcingActorTsoCode.java
+++ b/case-server/src/main/java/com/powsybl/caseserver/parsers/cgmes/SourcingActorTsoCode.java
@@ -20,7 +20,8 @@ public enum SourcingActorTsoCode {
     ES("REE", "REE-ES"),
     PT("REN", "REN-PT"),
     BE("BE"),
-    NL("NL");
+    NL("NL"),
+    UNDEFINED();
 
     private static final Map<String, SourcingActorTsoCode> BY_SOURCING_ACTOR = new HashMap<>();
 
@@ -39,6 +40,7 @@ public enum SourcingActorTsoCode {
     }
 
     public static SourcingActorTsoCode tsoFromSourcingActor(String sourcingActor) {
-        return BY_SOURCING_ACTOR.get(sourcingActor);
+        SourcingActorTsoCode tsoCode = BY_SOURCING_ACTOR.get(sourcingActor);
+        return tsoCode != null ? tsoCode : UNDEFINED;
     }
 }


### PR DESCRIPTION
Signed-off-by: HOMER Etienne <etiennehomer@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
https://github.com/gridsuite/gridstudy-app/issues/208


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
When parsing a cgmes file name, if no tso is parsed, the parser returns UNDEFINED enum value and not null.


**What is the current behavior?** *(You can also link to an open issue here)*
The parser returns null for the tsoCode and as the tsoCode is a non null lombok fied, the service crashes.


**What is the new behavior (if this is a feature change)?**
The parser returns SourcingActorTsoCode.UNDEFINED when no tso is parsed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
