### PR TITLE
Add a configurable elasticsearch client timeout

### DIFF
--- a/case-server/src/main/resources/application.yml
+++ b/case-server/src/main/resources/application.yml
@@ -24,5 +24,5 @@ spring:
       enabled : false
       host: localhost
       port: 9200
-      index: case-server
-      type: metadatas
+      client:
+        timeout : 60  # Seconds


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The timeout of the elasticsearch has 5 seconds as default value.
It's too limited to index a large network and if the indexing fails then the import also fails
org.springframework.dao.DataAccessResourceFailureException: 5,000 milliseconds timeout on connection http-outgoing-2 [ACTIVE]; nested exception is java.lang.RuntimeException: 5,000 milliseconds timeout on connection http-outgoing-2


**What is the new behavior (if this is a feature change)?**
The timeout is now configurable with 60 seconds as default value

