### PR TITLE
Remove jib.container.environment from pom which is defined in powsybl-parent-ws v7 + remove duplicated springdoc-openapi.version

### DIFF
--- a/case-server/pom.xml
+++ b/case-server/pom.xml
@@ -19,7 +19,6 @@
     <name>Case server</name>
 
     <properties>
-        <jib.container.environment>SPRING_PROFILES_ACTIVE=default</jib.container.environment>
         <springdoc-openapi.version>1.4.8</springdoc-openapi.version>
     </properties>
 

--- a/case-server/pom.xml
+++ b/case-server/pom.xml
@@ -18,10 +18,6 @@
     <artifactId>powsybl-case-server</artifactId>
     <name>Case server</name>
 
-    <properties>
-        <springdoc-openapi.version>1.4.8</springdoc-openapi.version>
-    </properties>
-
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Signed-off-by: sBouzols <sylvain.bouzols@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
